### PR TITLE
Refactor exception handling when loading the bindings

### DIFF
--- a/src/_cffi_src/build_bindings.py
+++ b/src/_cffi_src/build_bindings.py
@@ -3,12 +3,16 @@ import re
 from cffi import FFI
 
 
+# Load the `get_winfsp_dir` module as it contains useful logic
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
+MODULE_FILENAME = f"{BASEDIR}/../winfspy/plumbing/get_winfsp_dir.py"
+MODULE_CONTENTS = open(MODULE_FILENAME).read()
+MODULE_GLOBALS = {}
+exec(MODULE_CONTENTS, MODULE_GLOBALS)
 
-# import `get_winfsp_dir` the violent way given winfspy cannot be loaded yet
-exec(open(f"{BASEDIR}/../winfspy/plumbing/get_winfsp_dir.py").read())
-WINFSP_DIR = get_winfsp_dir()  # noqa
-WINFSP_LIB = get_winfsp_library_name()  # noqa
+# Get the WinFsp directory and library name
+WINFSP_DIR = MODULE_GLOBALS["get_winfsp_dir"]()
+WINFSP_LIB = MODULE_GLOBALS["get_winfsp_library_name"]()
 
 
 def strip_by_shaif(src):

--- a/src/_cffi_src/build_bindings.py
+++ b/src/_cffi_src/build_bindings.py
@@ -1,19 +1,14 @@
 import os
 import re
-import sys
 from cffi import FFI
-
-
-# see: https://docs.python.org/3/library/platform.html#platform.architecture
-is_64bits = sys.maxsize > 2 ** 32
 
 
 BASEDIR = os.path.dirname(os.path.abspath(__file__))
 
 # import `get_winfsp_dir` the violent way given winfspy cannot be loaded yet
-get_winfsp_dir = None
 exec(open(f"{BASEDIR}/../winfspy/plumbing/get_winfsp_dir.py").read())
-WINFSP_DIR = get_winfsp_dir()
+WINFSP_DIR = get_winfsp_dir()  # noqa
+WINFSP_LIB = get_winfsp_library_name()  # noqa
 
 
 def strip_by_shaif(src):
@@ -181,7 +176,7 @@ void configure_FSP_FSCTL_VOLUME_PARAMS(
 }
     """,
     include_dirs=[f"{WINFSP_DIR}/inc"],
-    libraries=["winfsp-" + ("x64" if is_64bits else "x86"), "advapi32"],
+    libraries=[WINFSP_LIB, "advapi32"],
     library_dirs=[f"{WINFSP_DIR}/lib"],
 )
 

--- a/src/winfspy/plumbing/bindings.py
+++ b/src/winfspy/plumbing/bindings.py
@@ -12,16 +12,15 @@ from .get_winfsp_dir import get_winfsp_bin_dir, get_winfsp_library_name
 # to the old way of adding a dll directory: customize the PATH environ
 # variable.
 
-BIN_DIR = get_winfsp_bin_dir()
+WINFSP_BIN_DIR = get_winfsp_bin_dir()
 
+# Modifiy %PATH% in any case as it is used by `ctypes.util.find_library`
+os.environ["PATH"] = f"{WINFSP_BIN_DIR};{os.environ.get('PATH')}"
 if sys.version_info >= (3, 8):
-    os.add_dll_directory(BIN_DIR)
-else:
-    os.environ["PATH"] = f"{BIN_DIR};{os.environ.get('PATH')}"
-
+    os.add_dll_directory(WINFSP_BIN_DIR)
 
 if not find_library(get_winfsp_library_name()):
-    raise RuntimeError(f"The WinFsp DLL could not be found in {BIN_DIR}")
+    raise RuntimeError(f"The WinFsp DLL could not be found in {WINFSP_BIN_DIR}")
 
 try:
     from ._bindings import ffi, lib  # noqa

--- a/src/winfspy/tests/test_bindings.py
+++ b/src/winfspy/tests/test_bindings.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import subprocess
+
+from winfspy.plumbing.get_winfsp_dir import get_winfsp_dir, get_winfsp_library_name
+
+
+def run_import_winfspy(env):
+    command = [sys.executable, "-c", "import winfspy"]
+    return subprocess.run(command, stderr=subprocess.PIPE, env=env)
+
+
+def test_load_bindings(tmp_path):
+    env = dict(os.environ)
+    library_path = str(get_winfsp_dir())
+    env["PATH"] = env["PATH"].replace(library_path, "")
+
+    result = run_import_winfspy(env)
+    assert result.returncode == 0
+
+    env["WINFSP_LIBRARY_PATH"] = library_path
+    result = run_import_winfspy(env)
+    assert result.returncode == 0
+
+    env["WINFSP_LIBRARY_PATH"] = "wrong"
+    result = run_import_winfspy(env)
+    assert result.returncode == 1
+    stderr = result.stderr.decode()
+    assert "RuntimeError: The provided WinFsp library path does not exist" in stderr
+
+    env["WINFSP_LIBRARY_PATH"] = str(tmp_path)
+    result = run_import_winfspy(env)
+    assert result.returncode == 1
+    stderr = result.stderr.decode()
+    assert "RuntimeError: The provided WinFsp binary path does not exist" in stderr
+
+    (tmp_path / "bin").mkdir()
+    result = run_import_winfspy(env)
+    assert result.returncode == 1
+    stderr = result.stderr.decode()
+    assert "RuntimeError: The WinFsp DLL could not be found in" in stderr
+
+    (tmp_path / "bin" / f"{get_winfsp_library_name()}.dll").touch()
+    result = run_import_winfspy(env)
+    assert result.returncode == 1
+    stderr = result.stderr.decode()
+    assert "The winfsp binding could not be imported" in stderr


### PR DESCRIPTION
Now, all failing operations should end up raising a RuntimeError.